### PR TITLE
feat: Improve download UX, progress feedback, version picker modal, offline detection

### DIFF
--- a/MFSRootViewController.m
+++ b/MFSRootViewController.m
@@ -1,5 +1,7 @@
 #import "MFSRootViewController.h"
+#import "MFSVersionPickerViewController.h"
 #import "CoreServices.h"
+#import <SystemConfiguration/SystemConfiguration.h>
 
 @interface SKUIItemStateCenter : NSObject
 
@@ -22,6 +24,10 @@
 + (id)defaultContext;
 @end
 
+@interface MFSRootViewController ()
+@property (nonatomic, strong) UIAlertController *progressAlert;
+@end
+
 @implementation MFSRootViewController
 
 - (void)loadView
@@ -30,38 +36,40 @@
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadSpecifiers) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
-- (NSMutableArray*)specifiers
+- (NSMutableArray *)specifiers
 {
-	if(!_specifiers)
+	if (!_specifiers)
 	{
 		_specifiers = [NSMutableArray new];
 
-		PSSpecifier* downloadGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
+		PSSpecifier *downloadGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
 		downloadGroupSpecifier.name = @"Download";
 		[_specifiers addObject:downloadGroupSpecifier];
 
-		PSSpecifier* downloadSpecifier = [PSSpecifier preferenceSpecifierNamed:@"Download" target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
+		PSSpecifier *downloadSpecifier = [PSSpecifier preferenceSpecifierNamed:@"Download" target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
 		downloadSpecifier.identifier = @"download";
 		[downloadSpecifier setProperty:@YES forKey:@"enabled"];
 		downloadSpecifier.buttonAction = @selector(downloadApp);
 		[_specifiers addObject:downloadSpecifier];
 
-		NSString* aboutText = [self getAboutText];
+		NSString *aboutText = [self getAboutText];
 		[downloadGroupSpecifier setProperty:aboutText forKey:@"footerText"];
 
-		PSSpecifier* installedGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
+		PSSpecifier *installedGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
 		installedGroupSpecifier.name = @"Installed Apps";
 		[_specifiers addObject:installedGroupSpecifier];
 
 		NSMutableArray *appSpecifiers = [NSMutableArray new];
-		[[LSApplicationWorkspace defaultWorkspace] enumerateApplicationsOfType:0 block:^(LSApplicationProxy* appProxy) {
-			PSSpecifier* appSpecifier = [PSSpecifier preferenceSpecifierNamed:appProxy.localizedName target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
+		[[LSApplicationWorkspace defaultWorkspace] enumerateApplicationsOfType:0 block:^(LSApplicationProxy *appProxy)
+		{
+			PSSpecifier *appSpecifier = [PSSpecifier preferenceSpecifierNamed:appProxy.localizedName target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
 			[appSpecifier setProperty:appProxy.bundleURL forKey:@"bundleURL"];
 			[appSpecifier setProperty:@YES forKey:@"enabled"];
 			appSpecifier.buttonAction = @selector(downloadAppShortcut:);
 			[appSpecifiers addObject:appSpecifier];
 		}];
-		[appSpecifiers sortUsingComparator:^NSComparisonResult(PSSpecifier* a, PSSpecifier* b) {
+		[appSpecifiers sortUsingComparator:^NSComparisonResult(PSSpecifier *a, PSSpecifier *b)
+		{
 			return [a.name compare:b.name];
 		}];
 		[_specifiers addObjectsFromArray:appSpecifiers];
@@ -70,111 +78,172 @@
 	return _specifiers;
 }
 
-- (void)downloadAppShortcut:(PSSpecifier*)specifier
+- (BOOL)isNetworkReachable
 {
-	NSURL* bundleURL = [specifier propertyForKey:@"bundleURL"];
-	NSDictionary* infoPlist = [NSDictionary dictionaryWithContentsOfFile:[bundleURL.path stringByAppendingPathComponent:@"Info.plist"]];
-	NSString* bundleId = infoPlist[@"CFBundleIdentifier"];
-	// NSLog(@"Bundle ID: %@", bundleId);
-	NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com/lookup?bundleId=%@&limit=1&media=software", bundleId]];
-	NSURLRequest* request = [NSURLRequest requestWithURL:url];
-	NSURLSessionDataTask* task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-		if(error)
+	SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithName(NULL, "apis.bilin.eu.org");
+	SCNetworkReachabilityFlags flags;
+	BOOL reachable = NO;
+	if (SCNetworkReachabilityGetFlags(reachability, &flags))
+	{
+		BOOL isReachable = (flags & kSCNetworkFlagsReachable) != 0;
+		BOOL needsConnection = (flags & kSCNetworkFlagsConnectionRequired) != 0;
+		reachable = isReachable && !needsConnection;
+	}
+	CFRelease(reachability);
+	return reachable;
+}
+
+- (void)downloadAppShortcut:(PSSpecifier *)specifier
+{
+	if (![self isNetworkReachable])
+	{
+		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
+		return;
+	}
+	NSURL *bundleURL = [specifier propertyForKey:@"bundleURL"];
+	NSDictionary *infoPlist = [NSDictionary dictionaryWithContentsOfFile:[bundleURL.path stringByAppendingPathComponent:@"Info.plist"]];
+	NSString *bundleId = infoPlist[@"CFBundleIdentifier"];
+	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com/lookup?bundleId=%@&limit=1&media=software", bundleId]];
+	NSURLRequest *request = [NSURLRequest requestWithURL:url];
+	NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
+	{
+		if (error)
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
 				[self showAlert:@"Error" message:error.localizedDescription];
 			});
 			return;
 		}
-		// NSLog(@"Response: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
-		NSError* jsonError = nil;
-		NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-		if(jsonError)
+		NSError *jsonError = nil;
+		NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+		if (jsonError)
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
 				[self showAlert:@"JSON Error" message:jsonError.localizedDescription];
 			});
 			return;
 		}
-		NSArray* results = json[@"results"];
-		if(results.count == 0)
+		NSArray *results = json[@"results"];
+		if (results.count == 0)
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[self showAlert:@"Error" message:@"No results"];
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
+				[self showAlert:@"Error" message:@"No results found for this app."];
 			});
 			return;
 		}
-		NSDictionary* app = results[0];
+		NSDictionary *app = results[0];
 		[self getAllAppVersionIdsAndPrompt:[app[@"trackId"] longLongValue]];
 	}];
 	[task resume];
 }
 
-- (NSString*)getAboutText
+- (NSString *)getAboutText
 {
 	return @"MuffinStore v1.2\nMade by Mineek\nhttps://github.com/mineek/MuffinStore";
 }
 
-- (void)showAlert:(NSString*)title message:(NSString*)message
+- (void)showAlert:(NSString *)title message:(NSString *)message
 {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		UIAlertController* alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-		UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+		UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
 		[alert addAction:okAction];
 		[self presentViewController:alert animated:YES completion:nil];
 	});
 }
 
+- (void)showDownloadProgressWithMessage:(NSString *)message
+{
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		if (self.progressAlert)
+		{
+			self.progressAlert.message = message;
+			return;
+		}
+		self.progressAlert = [UIAlertController alertControllerWithTitle:@"Downloading" message:message preferredStyle:UIAlertControllerStyleAlert];
+		UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+		indicator.translatesAutoresizingMaskIntoConstraints = NO;
+		[indicator startAnimating];
+		[self.progressAlert.view addSubview:indicator];
+		[NSLayoutConstraint activateConstraints:@[
+			[indicator.centerXAnchor constraintEqualToAnchor:self.progressAlert.view.centerXAnchor],
+			[indicator.bottomAnchor constraintEqualToAnchor:self.progressAlert.view.bottomAnchor constant:-20]
+		]];
+		[self presentViewController:self.progressAlert animated:YES completion:nil];
+	});
+}
+
+- (void)dismissDownloadProgress
+{
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		if (self.progressAlert)
+		{
+			[self.progressAlert dismissViewControllerAnimated:YES completion:nil];
+			self.progressAlert = nil;
+		}
+	});
+}
+
 - (void)getAllAppVersionIdsFromServer:(long long)appId
 {
-	//NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"http://192.168.1.180/olderVersions/%lld", appId]];
-	NSString* serverURL = @"https://apis.bilin.eu.org/history/";
-	NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%lld", serverURL, appId]];
-	NSURLRequest* request = [NSURLRequest requestWithURL:url];
-	NSURLSessionDataTask* task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-		if(error)
+	if (![self isNetworkReachable])
+	{
+		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
+		return;
+	}
+	NSString *serverURL = @"https://apis.bilin.eu.org/history/";
+	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%lld", serverURL, appId]];
+	NSURLRequest *request = [NSURLRequest requestWithURL:url];
+	NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
+	{
+		if (error)
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
 				[self showAlert:@"Error" message:error.localizedDescription];
 			});
 			return;
 		}
-		NSError* jsonError = nil;
-		NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-		if(jsonError)
+		NSError *jsonError = nil;
+		NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+		if (jsonError)
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
 				[self showAlert:@"JSON Error" message:jsonError.debugDescription];
 			});
 			return;
 		}
-		NSArray* versionIds = json[@"data"];
-		if(versionIds.count == 0)
+		NSArray *versionIds = json[@"data"];
+		if (versionIds.count == 0)
 		{
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[self showAlert:@"Error" message:@"No version IDs, internal error maybe?"];
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
+				[self showAlert:@"Error" message:@"No version IDs found. The server may not have records for this app."];
 			});
 			return;
 		}
-		dispatch_async(dispatch_get_main_queue(), ^{
-			UIAlertController* versionAlert = [UIAlertController alertControllerWithTitle:@"Version ID" message:@"Select the version ID of the app you want to download" preferredStyle:UIAlertControllerStyleActionSheet];
-			for(NSDictionary* versionId in versionIds)
+		dispatch_async(dispatch_get_main_queue(), ^
+		{
+			MFSVersionPickerViewController *picker = [[MFSVersionPickerViewController alloc] initWithVersions:versionIds completion:^(NSDictionary *selectedVersion)
 			{
-				UIAlertAction* versionAction = [UIAlertAction actionWithTitle:[NSString stringWithFormat:@"%@", versionId[@"bundle_version"]] style:UIAlertActionStyleDefault handler:^(UIAlertAction* action) {
-					[self downloadAppWithAppId:appId versionId:[versionId[@"external_identifier"] longLongValue]];
-				}];
-				[versionAlert addAction:versionAction];
+				[self downloadAppWithAppId:appId versionId:[selectedVersion[@"external_identifier"] longLongValue]];
+			}];
+			UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:picker];
+			nav.modalPresentationStyle = UIModalPresentationFormSheet;
+			if (@available(iOS 15.0, *))
+			{
+				UISheetPresentationController *sheet = nav.sheetPresentationController;
+				sheet.detents = @[UISheetPresentationControllerDetent.mediumDetent, UISheetPresentationControllerDetent.largeDetent];
+				sheet.prefersGrabberVisible = YES;
 			}
-			UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-			[versionAlert addAction:cancelAction];
-
-			// iPad fix
-			if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-				versionAlert.popoverPresentationController.sourceView = self.view;
-				versionAlert.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds), 0, 0);
-			}
-
-			[self presentViewController:versionAlert animated:YES completion:nil];
+			[self presentViewController:nav animated:YES completion:nil];
 		});
 	}];
 	[task resume];
@@ -182,47 +251,60 @@
 
 - (void)promptForVersionId:(long long)appId
 {
-	dispatch_async(dispatch_get_main_queue(), ^{
-	UIAlertController* versionAlert = [UIAlertController alertControllerWithTitle:@"Version ID" message:@"Enter the version ID of the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
-	[versionAlert addTextFieldWithConfigurationHandler:^(UITextField* textField) {
-		textField.placeholder = @"Version ID";
-	}];
-	UIAlertAction* downloadAction = [UIAlertAction actionWithTitle:@"Download" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action) {
-		long long versionId = [versionAlert.textFields.firstObject.text longLongValue];
-		[self downloadAppWithAppId:appId versionId:versionId];
-	}];
-	[versionAlert addAction:downloadAction];
-	UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-	[versionAlert addAction:cancelAction];
-	[self presentViewController:versionAlert animated:YES completion:nil];
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		UIAlertController *versionAlert = [UIAlertController alertControllerWithTitle:@"Version ID" message:@"Enter the version ID of the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
+		[versionAlert addTextFieldWithConfigurationHandler:^(UITextField *textField)
+		{
+			textField.placeholder = @"Version ID";
+			textField.keyboardType = UIKeyboardTypeNumberPad;
+		}];
+		UIAlertAction *downloadAction = [UIAlertAction actionWithTitle:@"Download" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+		{
+			long long versionId = [versionAlert.textFields.firstObject.text longLongValue];
+			[self downloadAppWithAppId:appId versionId:versionId];
+		}];
+		[versionAlert addAction:downloadAction];
+		UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+		[versionAlert addAction:cancelAction];
+		[self presentViewController:versionAlert animated:YES completion:nil];
 	});
 }
 
 - (void)getAllAppVersionIdsAndPrompt:(long long)appId
 {
-	dispatch_async(dispatch_get_main_queue(), ^{
-	UIAlertController* promptAlert = [UIAlertController alertControllerWithTitle:@"Version ID" message:@"Do you want to enter the version ID manually or request the list of version IDs from the server?" preferredStyle:UIAlertControllerStyleAlert];
-	UIAlertAction* manualAction = [UIAlertAction actionWithTitle:@"Manual" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action) {
-		[self promptForVersionId:appId];
-	}];
-	[promptAlert addAction:manualAction];
-	UIAlertAction* serverAction = [UIAlertAction actionWithTitle:@"Server" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action) {
-		[self getAllAppVersionIdsFromServer:appId];
-	}];
-	[promptAlert addAction:serverAction];
-	UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-	[promptAlert addAction:cancelAction];
-	[self presentViewController:promptAlert animated:YES completion:nil];
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		UIAlertController *promptAlert = [UIAlertController alertControllerWithTitle:@"Version Selection" message:@"Choose how to select the app version to download." preferredStyle:UIAlertControllerStyleAlert];
+		UIAlertAction *serverAction = [UIAlertAction actionWithTitle:@"Browse Version List" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+		{
+			[self getAllAppVersionIdsFromServer:appId];
+		}];
+		[promptAlert addAction:serverAction];
+		UIAlertAction *manualAction = [UIAlertAction actionWithTitle:@"Enter Version ID Manually" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+		{
+			[self promptForVersionId:appId];
+		}];
+		[promptAlert addAction:manualAction];
+		UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+		[promptAlert addAction:cancelAction];
+		[self presentViewController:promptAlert animated:YES completion:nil];
 	});
 }
 
 - (void)downloadAppWithAppId:(long long)appId versionId:(long long)versionId
 {
-	NSString* adamId = [NSString stringWithFormat:@"%lld", appId];
-	NSString* pricingParameters = @"pricingParameter";
-	NSString* appExtVrsId = [NSString stringWithFormat:@"%lld", versionId];
-	NSString* installed = @"0";
-	NSString* offerString = nil;
+	if (![self isNetworkReachable])
+	{
+		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
+		return;
+	}
+	[self showDownloadProgressWithMessage:@"Initiating download…"];
+	NSString *adamId = [NSString stringWithFormat:@"%lld", appId];
+	NSString *pricingParameters = @"pricingParameter";
+	NSString *appExtVrsId = [NSString stringWithFormat:@"%lld", versionId];
+	NSString *installed = @"0";
+	NSString *offerString = nil;
 	if (versionId == 0)
 	{
 		offerString = [NSString stringWithFormat:@"productType=C&price=0&salableAdamId=%@&pricingParameters=%@&clientBuyId=1&installed=%@&trolled=1", adamId, pricingParameters, installed];
@@ -231,36 +313,45 @@
 	{
 		offerString = [NSString stringWithFormat:@"productType=C&price=0&salableAdamId=%@&pricingParameters=%@&appExtVrsId=%@&clientBuyId=1&installed=%@&trolled=1", adamId, pricingParameters, appExtVrsId, installed];
 	}
-	NSDictionary* offerDict = @{@"buyParams": offerString};
-	NSDictionary* itemDict = @{@"_itemOffer": adamId};
-	SKUIItemOffer* offer = [[SKUIItemOffer alloc] initWithLookupDictionary:offerDict];
-	SKUIItem* item = [[SKUIItem alloc] initWithLookupDictionary:itemDict];
+	NSDictionary *offerDict = @{@"buyParams": offerString};
+	NSDictionary *itemDict = @{@"_itemOffer": adamId};
+	SKUIItemOffer *offer = [[SKUIItemOffer alloc] initWithLookupDictionary:offerDict];
+	SKUIItem *item = [[SKUIItem alloc] initWithLookupDictionary:itemDict];
 	[item setValue:offer forKey:@"_itemOffer"];
 	[item setValue:@"iosSoftware" forKey:@"_itemKindString"];
-	//[item setValue:@(versionId) forKey:@"_versionIdentifier"];
-	if(versionId != 0)
+	if (versionId != 0)
 	{
 		[item setValue:@(versionId) forKey:@"_versionIdentifier"];
 	}
-	SKUIItemStateCenter* center = [SKUIItemStateCenter defaultCenter];
-	NSArray* items = @[item];
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[center _performPurchases:[center _newPurchasesWithItems:items] hasBundlePurchase:0 withClientContext:[SKUIClientContext defaultContext] completionBlock:^(id arg1){}];
+	SKUIItemStateCenter *center = [SKUIItemStateCenter defaultCenter];
+	NSArray *items = @[item];
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		[self showDownloadProgressWithMessage:@"Purchase request sent. The download will begin in the background."];
+		[center _performPurchases:[center _newPurchasesWithItems:items] hasBundlePurchase:0 withClientContext:[SKUIClientContext defaultContext] completionBlock:^(id arg1)
+		{
+			[self dismissDownloadProgress];
+		}];
 	});
 }
 
-- (void)downloadAppWithLink:(NSString*)link
+- (void)downloadAppWithLink:(NSString *)link
 {
-	NSString* targetAppIdParsed = nil;
-	if([link containsString:@"id"])
+	if (![self isNetworkReachable])
 	{
-		NSArray* components = [link componentsSeparatedByString:@"id"];
-		if(components.count < 2)
+		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
+		return;
+	}
+	NSString *targetAppIdParsed = nil;
+	if ([link containsString:@"id"])
+	{
+		NSArray *components = [link componentsSeparatedByString:@"id"];
+		if (components.count < 2)
 		{
 			[self showAlert:@"Error" message:@"Invalid link"];
 			return;
 		}
-		NSArray* idComponents = [components[1] componentsSeparatedByString:@"?"];
+		NSArray *idComponents = [components[1] componentsSeparatedByString:@"?"];
 		targetAppIdParsed = idComponents[0];
 	}
 	else
@@ -268,22 +359,25 @@
 		[self showAlert:@"Error" message:@"Invalid link"];
 		return;
 	}
-	dispatch_async(dispatch_get_main_queue(), ^{
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
 		[self getAllAppVersionIdsAndPrompt:[targetAppIdParsed longLongValue]];
 	});
 }
 
 - (void)downloadApp
 {
-	UIAlertController* linkAlert = [UIAlertController alertControllerWithTitle:@"App Link" message:@"Enter the link to the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
-	[linkAlert addTextFieldWithConfigurationHandler:^(UITextField* textField) {
-		textField.placeholder = @"App Link";
+	UIAlertController *linkAlert = [UIAlertController alertControllerWithTitle:@"App Link" message:@"Enter the App Store link to the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
+	[linkAlert addTextFieldWithConfigurationHandler:^(UITextField *textField)
+	{
+		textField.placeholder = @"https://apps.apple.com/app/idXXXXXXXXX";
 	}];
-	UIAlertAction* downloadAction = [UIAlertAction actionWithTitle:@"Download" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action) {
+	UIAlertAction *downloadAction = [UIAlertAction actionWithTitle:@"Continue" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+	{
 		[self downloadAppWithLink:linkAlert.textFields.firstObject.text];
 	}];
 	[linkAlert addAction:downloadAction];
-	UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+	UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
 	[linkAlert addAction:cancelAction];
 	[self presentViewController:linkAlert animated:YES completion:nil];
 }

--- a/MFSRootViewController.m
+++ b/MFSRootViewController.m
@@ -25,7 +25,7 @@
 @end
 
 @interface MFSRootViewController ()
-@property (nonatomic, strong) UIAlertController *progressAlert;
+@property (nonatomic, strong) UIAlertController* progressAlert;
 @end
 
 @implementation MFSRootViewController
@@ -36,45 +36,45 @@
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadSpecifiers) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
-- (NSMutableArray *)specifiers
+- (NSMutableArray*)specifiers
 {
 	if (!_specifiers)
 	{
 		_specifiers = [NSMutableArray new];
 
-		PSSpecifier *downloadGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
+		PSSpecifier* downloadGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
 		downloadGroupSpecifier.name = @"Download";
 		[_specifiers addObject:downloadGroupSpecifier];
 
-		PSSpecifier *downloadSpecifier = [PSSpecifier preferenceSpecifierNamed:@"Download" target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
+		PSSpecifier* downloadSpecifier = [PSSpecifier preferenceSpecifierNamed:@"Download" target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
 		downloadSpecifier.identifier = @"download";
 		[downloadSpecifier setProperty:@YES forKey:@"enabled"];
 		downloadSpecifier.buttonAction = @selector(downloadApp);
 		[_specifiers addObject:downloadSpecifier];
 
-		NSString *aboutText = [self getAboutText];
+		NSString* aboutText = [self getAboutText];
 		[downloadGroupSpecifier setProperty:aboutText forKey:@"footerText"];
 
-		PSSpecifier *installedGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
+		PSSpecifier* installedGroupSpecifier = [PSSpecifier emptyGroupSpecifier];
 		installedGroupSpecifier.name = @"Installed Apps";
 		[_specifiers addObject:installedGroupSpecifier];
 
-		NSMutableArray *appSpecifiers = [NSMutableArray new];
-		[[LSApplicationWorkspace defaultWorkspace] enumerateApplicationsOfType:0 block:^(LSApplicationProxy *appProxy)
+		NSMutableArray* appSpecifiers = [NSMutableArray new];
+		[[LSApplicationWorkspace defaultWorkspace] enumerateApplicationsOfType:0 block:^(LSApplicationProxy* appProxy)
 		{
-			PSSpecifier *appSpecifier = [PSSpecifier preferenceSpecifierNamed:appProxy.localizedName target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
+			PSSpecifier* appSpecifier = [PSSpecifier preferenceSpecifierNamed:appProxy.localizedName target:self set:nil get:nil detail:nil cell:PSButtonCell edit:nil];
 			[appSpecifier setProperty:appProxy.bundleURL forKey:@"bundleURL"];
 			[appSpecifier setProperty:@YES forKey:@"enabled"];
 			appSpecifier.buttonAction = @selector(downloadAppShortcut:);
 			[appSpecifiers addObject:appSpecifier];
 		}];
-		[appSpecifiers sortUsingComparator:^NSComparisonResult(PSSpecifier *a, PSSpecifier *b)
+		[appSpecifiers sortUsingComparator:^NSComparisonResult(PSSpecifier* a, PSSpecifier* b)
 		{
 			return [a.name compare:b.name];
 		}];
 		[_specifiers addObjectsFromArray:appSpecifiers];
 	}
-	[(UINavigationItem *)self.navigationItem setTitle:@"MuffinStore"];
+	[(UINavigationItem*)self.navigationItem setTitle:@"MuffinStore"];
 	return _specifiers;
 }
 
@@ -93,19 +93,19 @@
 	return reachable;
 }
 
-- (void)downloadAppShortcut:(PSSpecifier *)specifier
+- (void)downloadAppShortcut:(PSSpecifier*)specifier
 {
 	if (![self isNetworkReachable])
 	{
 		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
 		return;
 	}
-	NSURL *bundleURL = [specifier propertyForKey:@"bundleURL"];
-	NSDictionary *infoPlist = [NSDictionary dictionaryWithContentsOfFile:[bundleURL.path stringByAppendingPathComponent:@"Info.plist"]];
-	NSString *bundleId = infoPlist[@"CFBundleIdentifier"];
-	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com/lookup?bundleId=%@&limit=1&media=software", bundleId]];
-	NSURLRequest *request = [NSURLRequest requestWithURL:url];
-	NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
+	NSURL* bundleURL = [specifier propertyForKey:@"bundleURL"];
+	NSDictionary* infoPlist = [NSDictionary dictionaryWithContentsOfFile:[bundleURL.path stringByAppendingPathComponent:@"Info.plist"]];
+	NSString* bundleId = infoPlist[@"CFBundleIdentifier"];
+	NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com/lookup?bundleId=%@&limit=1&media=software", bundleId]];
+	NSURLRequest* request = [NSURLRequest requestWithURL:url];
+	NSURLSessionDataTask* task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData* data, NSURLResponse* response, NSError* error)
 	{
 		if (error)
 		{
@@ -115,8 +115,8 @@
 			});
 			return;
 		}
-		NSError *jsonError = nil;
-		NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+		NSError* jsonError = nil;
+		NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
 		if (jsonError)
 		{
 			dispatch_async(dispatch_get_main_queue(), ^
@@ -125,7 +125,7 @@
 			});
 			return;
 		}
-		NSArray *results = json[@"results"];
+		NSArray* results = json[@"results"];
 		if (results.count == 0)
 		{
 			dispatch_async(dispatch_get_main_queue(), ^
@@ -134,29 +134,29 @@
 			});
 			return;
 		}
-		NSDictionary *app = results[0];
+		NSDictionary* app = results[0];
 		[self getAllAppVersionIdsAndPrompt:[app[@"trackId"] longLongValue]];
 	}];
 	[task resume];
 }
 
-- (NSString *)getAboutText
+- (NSString*)getAboutText
 {
 	return @"MuffinStore v1.2\nMade by Mineek\nhttps://github.com/mineek/MuffinStore";
 }
 
-- (void)showAlert:(NSString *)title message:(NSString *)message
+- (void)showAlert:(NSString*)title message:(NSString*)message
 {
 	dispatch_async(dispatch_get_main_queue(), ^
 	{
-		UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-		UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+		UIAlertController* alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+		UIAlertAction* okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
 		[alert addAction:okAction];
 		[self presentViewController:alert animated:YES completion:nil];
 	});
 }
 
-- (void)showDownloadProgressWithMessage:(NSString *)message
+- (void)showDownloadProgressWithMessage:(NSString*)message
 {
 	dispatch_async(dispatch_get_main_queue(), ^
 	{
@@ -166,7 +166,7 @@
 			return;
 		}
 		self.progressAlert = [UIAlertController alertControllerWithTitle:@"Downloading" message:message preferredStyle:UIAlertControllerStyleAlert];
-		UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+		UIActivityIndicatorView* indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
 		indicator.translatesAutoresizingMaskIntoConstraints = NO;
 		[indicator startAnimating];
 		[self.progressAlert.view addSubview:indicator];
@@ -197,10 +197,10 @@
 		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
 		return;
 	}
-	NSString *serverURL = @"https://apis.bilin.eu.org/history/";
-	NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%lld", serverURL, appId]];
-	NSURLRequest *request = [NSURLRequest requestWithURL:url];
-	NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
+	NSString* serverURL = @"https://apis.bilin.eu.org/history/";
+	NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%lld", serverURL, appId]];
+	NSURLRequest* request = [NSURLRequest requestWithURL:url];
+	NSURLSessionDataTask* task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData* data, NSURLResponse* response, NSError* error)
 	{
 		if (error)
 		{
@@ -210,8 +210,8 @@
 			});
 			return;
 		}
-		NSError *jsonError = nil;
-		NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+		NSError* jsonError = nil;
+		NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
 		if (jsonError)
 		{
 			dispatch_async(dispatch_get_main_queue(), ^
@@ -220,7 +220,7 @@
 			});
 			return;
 		}
-		NSArray *versionIds = json[@"data"];
+		NSArray* versionIds = json[@"data"];
 		if (versionIds.count == 0)
 		{
 			dispatch_async(dispatch_get_main_queue(), ^
@@ -231,15 +231,15 @@
 		}
 		dispatch_async(dispatch_get_main_queue(), ^
 		{
-			MFSVersionPickerViewController *picker = [[MFSVersionPickerViewController alloc] initWithVersions:versionIds completion:^(NSDictionary *selectedVersion)
+			MFSVersionPickerViewController* picker = [[MFSVersionPickerViewController alloc] initWithVersions:versionIds completion:^(NSDictionary* selectedVersion)
 			{
 				[self downloadAppWithAppId:appId versionId:[selectedVersion[@"external_identifier"] longLongValue]];
 			}];
-			UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:picker];
+			UINavigationController* nav = [[UINavigationController alloc] initWithRootViewController:picker];
 			nav.modalPresentationStyle = UIModalPresentationFormSheet;
 			if (@available(iOS 15.0, *))
 			{
-				UISheetPresentationController *sheet = nav.sheetPresentationController;
+				UISheetPresentationController* sheet = nav.sheetPresentationController;
 				sheet.detents = @[UISheetPresentationControllerDetent.mediumDetent, UISheetPresentationControllerDetent.largeDetent];
 				sheet.prefersGrabberVisible = YES;
 			}
@@ -253,19 +253,19 @@
 {
 	dispatch_async(dispatch_get_main_queue(), ^
 	{
-		UIAlertController *versionAlert = [UIAlertController alertControllerWithTitle:@"Version ID" message:@"Enter the version ID of the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
-		[versionAlert addTextFieldWithConfigurationHandler:^(UITextField *textField)
+		UIAlertController* versionAlert = [UIAlertController alertControllerWithTitle:@"Version ID" message:@"Enter the version ID of the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
+		[versionAlert addTextFieldWithConfigurationHandler:^(UITextField* textField)
 		{
 			textField.placeholder = @"Version ID";
 			textField.keyboardType = UIKeyboardTypeNumberPad;
 		}];
-		UIAlertAction *downloadAction = [UIAlertAction actionWithTitle:@"Download" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+		UIAlertAction* downloadAction = [UIAlertAction actionWithTitle:@"Download" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
 		{
 			long long versionId = [versionAlert.textFields.firstObject.text longLongValue];
 			[self downloadAppWithAppId:appId versionId:versionId];
 		}];
 		[versionAlert addAction:downloadAction];
-		UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+		UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
 		[versionAlert addAction:cancelAction];
 		[self presentViewController:versionAlert animated:YES completion:nil];
 	});
@@ -275,18 +275,18 @@
 {
 	dispatch_async(dispatch_get_main_queue(), ^
 	{
-		UIAlertController *promptAlert = [UIAlertController alertControllerWithTitle:@"Version Selection" message:@"Choose how to select the app version to download." preferredStyle:UIAlertControllerStyleAlert];
-		UIAlertAction *serverAction = [UIAlertAction actionWithTitle:@"Browse Version List" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+		UIAlertController* promptAlert = [UIAlertController alertControllerWithTitle:@"Version Selection" message:@"Choose how to select the app version to download." preferredStyle:UIAlertControllerStyleAlert];
+		UIAlertAction* serverAction = [UIAlertAction actionWithTitle:@"Browse Version List" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
 		{
 			[self getAllAppVersionIdsFromServer:appId];
 		}];
 		[promptAlert addAction:serverAction];
-		UIAlertAction *manualAction = [UIAlertAction actionWithTitle:@"Enter Version ID Manually" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+		UIAlertAction* manualAction = [UIAlertAction actionWithTitle:@"Enter Version ID Manually" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
 		{
 			[self promptForVersionId:appId];
 		}];
 		[promptAlert addAction:manualAction];
-		UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+		UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
 		[promptAlert addAction:cancelAction];
 		[self presentViewController:promptAlert animated:YES completion:nil];
 	});
@@ -300,11 +300,11 @@
 		return;
 	}
 	[self showDownloadProgressWithMessage:@"Initiating download…"];
-	NSString *adamId = [NSString stringWithFormat:@"%lld", appId];
-	NSString *pricingParameters = @"pricingParameter";
-	NSString *appExtVrsId = [NSString stringWithFormat:@"%lld", versionId];
-	NSString *installed = @"0";
-	NSString *offerString = nil;
+	NSString* adamId = [NSString stringWithFormat:@"%lld", appId];
+	NSString* pricingParameters = @"pricingParameter";
+	NSString* appExtVrsId = [NSString stringWithFormat:@"%lld", versionId];
+	NSString* installed = @"0";
+	NSString* offerString = nil;
 	if (versionId == 0)
 	{
 		offerString = [NSString stringWithFormat:@"productType=C&price=0&salableAdamId=%@&pricingParameters=%@&clientBuyId=1&installed=%@&trolled=1", adamId, pricingParameters, installed];
@@ -313,18 +313,18 @@
 	{
 		offerString = [NSString stringWithFormat:@"productType=C&price=0&salableAdamId=%@&pricingParameters=%@&appExtVrsId=%@&clientBuyId=1&installed=%@&trolled=1", adamId, pricingParameters, appExtVrsId, installed];
 	}
-	NSDictionary *offerDict = @{@"buyParams": offerString};
-	NSDictionary *itemDict = @{@"_itemOffer": adamId};
-	SKUIItemOffer *offer = [[SKUIItemOffer alloc] initWithLookupDictionary:offerDict];
-	SKUIItem *item = [[SKUIItem alloc] initWithLookupDictionary:itemDict];
+	NSDictionary* offerDict = @{@"buyParams": offerString};
+	NSDictionary* itemDict = @{@"_itemOffer": adamId};
+	SKUIItemOffer* offer = [[SKUIItemOffer alloc] initWithLookupDictionary:offerDict];
+	SKUIItem* item = [[SKUIItem alloc] initWithLookupDictionary:itemDict];
 	[item setValue:offer forKey:@"_itemOffer"];
 	[item setValue:@"iosSoftware" forKey:@"_itemKindString"];
 	if (versionId != 0)
 	{
 		[item setValue:@(versionId) forKey:@"_versionIdentifier"];
 	}
-	SKUIItemStateCenter *center = [SKUIItemStateCenter defaultCenter];
-	NSArray *items = @[item];
+	SKUIItemStateCenter* center = [SKUIItemStateCenter defaultCenter];
+	NSArray* items = @[item];
 	dispatch_async(dispatch_get_main_queue(), ^
 	{
 		[self showDownloadProgressWithMessage:@"Purchase request sent. The download will begin in the background."];
@@ -335,23 +335,23 @@
 	});
 }
 
-- (void)downloadAppWithLink:(NSString *)link
+- (void)downloadAppWithLink:(NSString*)link
 {
 	if (![self isNetworkReachable])
 	{
 		[self showAlert:@"No Internet" message:@"Please check your internet connection and try again."];
 		return;
 	}
-	NSString *targetAppIdParsed = nil;
+	NSString* targetAppIdParsed = nil;
 	if ([link containsString:@"id"])
 	{
-		NSArray *components = [link componentsSeparatedByString:@"id"];
+		NSArray* components = [link componentsSeparatedByString:@"id"];
 		if (components.count < 2)
 		{
 			[self showAlert:@"Error" message:@"Invalid link"];
 			return;
 		}
-		NSArray *idComponents = [components[1] componentsSeparatedByString:@"?"];
+		NSArray* idComponents = [components[1] componentsSeparatedByString:@"?"];
 		targetAppIdParsed = idComponents[0];
 	}
 	else
@@ -367,17 +367,17 @@
 
 - (void)downloadApp
 {
-	UIAlertController *linkAlert = [UIAlertController alertControllerWithTitle:@"App Link" message:@"Enter the App Store link to the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
-	[linkAlert addTextFieldWithConfigurationHandler:^(UITextField *textField)
+	UIAlertController* linkAlert = [UIAlertController alertControllerWithTitle:@"App Link" message:@"Enter the App Store link to the app you want to download" preferredStyle:UIAlertControllerStyleAlert];
+	[linkAlert addTextFieldWithConfigurationHandler:^(UITextField* textField)
 	{
 		textField.placeholder = @"https://apps.apple.com/app/idXXXXXXXXX";
 	}];
-	UIAlertAction *downloadAction = [UIAlertAction actionWithTitle:@"Continue" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action)
+	UIAlertAction* downloadAction = [UIAlertAction actionWithTitle:@"Continue" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
 	{
 		[self downloadAppWithLink:linkAlert.textFields.firstObject.text];
 	}];
 	[linkAlert addAction:downloadAction];
-	UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+	UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
 	[linkAlert addAction:cancelAction];
 	[self presentViewController:linkAlert animated:YES completion:nil];
 }

--- a/MFSVersionPickerViewController.h
+++ b/MFSVersionPickerViewController.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+typedef void (^MFSVersionPickerCompletion)(NSDictionary *selectedVersion);
+
+@interface MFSVersionPickerViewController : UITableViewController
+
+@property (nonatomic, copy) MFSVersionPickerCompletion completionHandler;
+
+- (instancetype)initWithVersions:(NSArray *)versions completion:(MFSVersionPickerCompletion)completion;
+
+@end

--- a/MFSVersionPickerViewController.h
+++ b/MFSVersionPickerViewController.h
@@ -1,11 +1,11 @@
 #import <UIKit/UIKit.h>
 
-typedef void (^MFSVersionPickerCompletion)(NSDictionary *selectedVersion);
+typedef void (^MFSVersionPickerCompletion)(NSDictionary* selectedVersion);
 
 @interface MFSVersionPickerViewController : UITableViewController
 
 @property (nonatomic, copy) MFSVersionPickerCompletion completionHandler;
 
-- (instancetype)initWithVersions:(NSArray *)versions completion:(MFSVersionPickerCompletion)completion;
+- (instancetype)initWithVersions:(NSArray*)versions completion:(MFSVersionPickerCompletion)completion;
 
 @end

--- a/MFSVersionPickerViewController.m
+++ b/MFSVersionPickerViewController.m
@@ -1,12 +1,12 @@
 #import "MFSVersionPickerViewController.h"
 
 @interface MFSVersionPickerViewController ()
-@property (nonatomic, strong) NSArray *versions;
+@property (nonatomic, strong) NSArray* versions;
 @end
 
 @implementation MFSVersionPickerViewController
 
-- (instancetype)initWithVersions:(NSArray *)versions completion:(MFSVersionPickerCompletion)completion
+- (instancetype)initWithVersions:(NSArray*)versions completion:(MFSVersionPickerCompletion)completion
 {
 	self = [super initWithStyle:UITableViewStyleInsetGrouped];
 	if (self)
@@ -22,7 +22,7 @@
 	[super viewDidLoad];
 	self.title = @"Select Version";
 	[self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"VersionCell"];
-	UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelTapped)];
+	UIBarButtonItem* cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelTapped)];
 	self.navigationItem.leftBarButtonItem = cancelButton;
 }
 
@@ -31,30 +31,30 @@
 	[self dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+- (NSInteger)numberOfSectionsInTableView:(UITableView*)tableView
 {
 	return 1;
 }
 
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+- (NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection:(NSInteger)section
 {
 	return self.versions.count;
 }
 
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+- (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath
 {
-	UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"VersionCell" forIndexPath:indexPath];
-	NSDictionary *version = self.versions[indexPath.row];
+	UITableViewCell* cell = [tableView dequeueReusableCellWithIdentifier:@"VersionCell" forIndexPath:indexPath];
+	NSDictionary* version = self.versions[indexPath.row];
 	cell.textLabel.text = version[@"bundle_version"];
 	cell.textLabel.font = [UIFont monospacedDigitSystemFontOfSize:15 weight:UIFontWeightRegular];
 	cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 	return cell;
 }
 
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+- (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath
 {
 	[tableView deselectRowAtIndexPath:indexPath animated:YES];
-	NSDictionary *selected = self.versions[indexPath.row];
+	NSDictionary* selected = self.versions[indexPath.row];
 	[self dismissViewControllerAnimated:YES completion:^
 	{
 		if (self.completionHandler)
@@ -64,7 +64,7 @@
 	}];
 }
 
-- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+- (NSString*)tableView:(UITableView*)tableView titleForHeaderInSection:(NSInteger)section
 {
 	return [NSString stringWithFormat:@"%lu versions available", (unsigned long)self.versions.count];
 }

--- a/MFSVersionPickerViewController.m
+++ b/MFSVersionPickerViewController.m
@@ -1,0 +1,72 @@
+#import "MFSVersionPickerViewController.h"
+
+@interface MFSVersionPickerViewController ()
+@property (nonatomic, strong) NSArray *versions;
+@end
+
+@implementation MFSVersionPickerViewController
+
+- (instancetype)initWithVersions:(NSArray *)versions completion:(MFSVersionPickerCompletion)completion
+{
+	self = [super initWithStyle:UITableViewStyleInsetGrouped];
+	if (self)
+	{
+		_versions = versions;
+		_completionHandler = completion;
+	}
+	return self;
+}
+
+- (void)viewDidLoad
+{
+	[super viewDidLoad];
+	self.title = @"Select Version";
+	[self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"VersionCell"];
+	UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelTapped)];
+	self.navigationItem.leftBarButtonItem = cancelButton;
+}
+
+- (void)cancelTapped
+{
+	[self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+	return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+	return self.versions.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+	UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"VersionCell" forIndexPath:indexPath];
+	NSDictionary *version = self.versions[indexPath.row];
+	cell.textLabel.text = version[@"bundle_version"];
+	cell.textLabel.font = [UIFont monospacedDigitSystemFontOfSize:15 weight:UIFontWeightRegular];
+	cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+	return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+	[tableView deselectRowAtIndexPath:indexPath animated:YES];
+	NSDictionary *selected = self.versions[indexPath.row];
+	[self dismissViewControllerAnimated:YES completion:^
+	{
+		if (self.completionHandler)
+		{
+			self.completionHandler(selected);
+		}
+	}];
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+	return [NSString stringWithFormat:@"%lu versions available", (unsigned long)self.versions.count];
+}
+
+@end

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include $(THEOS)/makefiles/common.mk
 APPLICATION_NAME = MuffinStore
 
 MuffinStore_FILES = $(wildcard *.m)
-MuffinStore_FRAMEWORKS = UIKit CoreGraphics CoreServices
+MuffinStore_FRAMEWORKS = UIKit CoreGraphics CoreServices SystemConfiguration
 MuffinStore_PRIVATE_FRAMEWORKS = Preferences StoreKitUI
 MuffinStore_CFLAGS = -fobjc-arc
 MuffinStore_CODESIGN_FLAGS = -Sentitlements.plist

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -50,7 +50,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.1</string>
+	<string>1.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIDeviceFamily</key>


### PR DESCRIPTION
## Changes

### Download progress feedback
Shows a spinner alert while the purchase request is being initiated, updating
its message when the request is dispatched. Dismisses automatically once the
completion block fires.

### Version picker modal
Replaces the `UIAlertController` action sheet (which breaks with many versions)
with a scrollable `UITableViewController` presented as a sheet modal. Works
correctly on both iPhone and iPad without any popover workarounds. Detents are
set to medium/large on iOS 15+.

### Offline detection
Checks network reachability via `SCNetworkReachability` before any network
call. If there is no internet connection, an alert is shown immediately and
the request is not made.

From my testing, listing YouTube app versions went from several seconds to 1-2 seconds on a A8X device.

<img width="2048" height="1536" alt="IMG_0015" src="https://github.com/user-attachments/assets/88728223-c07e-4a7b-ab5c-af810837c81a" />
